### PR TITLE
Fix invalid header in the subscribe package

### DIFF
--- a/phpMQTT.php
+++ b/phpMQTT.php
@@ -202,7 +202,7 @@ class phpMQTT {
 			$this->topics[$key] = $topic; 
 		}
 
-		$cmd = 0x80;
+		$cmd = 0x82;
 		//$qos
 		$cmd +=	($qos << 1);
 


### PR DESCRIPTION
Fixed Issue: The lib (and all forks of it, obviously) send an invalid header in the subscribe package. Replaced 0x80 with 0x82 in the subscribe function of phpmqtt.php. Thanks to psorowka